### PR TITLE
Rollup of outstanding PRs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "cheddar"
 doc = false
 
 [dependencies]
-syntex_syntax = "0.24.0"
+syntex_errors = "0.42.0"
+syntex_syntax = "0.42.0"
 toml = "0.1.25"
 clap = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ doc = false
 
 [dependencies]
 syntex_syntax = "0.24.0"
-toml = "0.1.25"
-clap = "1"
+toml = "0.2"
+clap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ documentation = "http://sean1708.github.io/rusty-cheddar"
 
 license = "MIT"
 
+[features]
+default = ["with-syntex"]
+with-syntex = [
+    "syntex_errors",
+    "syntex_syntax",
+]
+
 [lib]
 name = "cheddar"
 
@@ -21,7 +28,7 @@ name = "cheddar"
 doc = false
 
 [dependencies]
-syntex_errors = "0.42.0"
-syntex_syntax = "0.42.0"
+syntex_errors = {version = "0.42.0", optional = true}
+syntex_syntax = {version = "0.42.0", optional = true}
 toml = "0.1.25"
 clap = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ doc = false
 
 [dependencies]
 syntex_syntax = "0.24.0"
-toml = "0.1.25"
+toml = "0.3.2"
 clap = "1"

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ rusty-cheddar can not yet search other modules.
 
 The very important exception to this rule are the C ABI types defined in
 the `libc` crate and `std::os::raw`. Types from these two modules _must_
-be fully qualified (e.g. `libc::c_void` or `std::os::raw::c_longlong)
+be fully qualified (e.g. `libc::c_void` or `std::os::raw::c_longlong`)
 so that they can be converted properly. Importing them with a `use`
 statement will not work.
 

--- a/src/bin/cheddar.rs
+++ b/src/bin/cheddar.rs
@@ -3,7 +3,7 @@ extern crate cheddar;
 
 fn main() {
     let matches = clap::App::new("cheddar")
-        .version(&crate_version!())
+        .version(crate_version!())
         .author("Sean Marshallsay <srm.1708@gmail.com>")
         .about("create a C header file using a Rust source file")
         .arg(clap::Arg::with_name("FILE")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,8 +272,16 @@
 //! [the cargo docs]: http://doc.crates.io/build-script.html
 //! [repo]: https://github.com/Sean1708/rusty-cheddar
 
+#![cfg_attr(not(feature = "with-syntex"), feature(rustc_private))]
+
+#[cfg(feature = "with-syntex")]
 extern crate syntex_errors as errors;
+#[cfg(not(feature = "with-syntex"))]
+extern crate rustc_errors as errors;
+#[cfg(feature = "with-syntex")]
 extern crate syntex_syntax as syntax;
+#[cfg(not(feature = "with-syntex"))]
+extern crate syntax;
 extern crate toml;
 
 use std::convert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@
 //! [the cargo docs]: http://doc.crates.io/build-script.html
 //! [repo]: https://github.com/Sean1708/rusty-cheddar
 
+extern crate syntex_errors as errors;
 extern crate syntex_syntax as syntax;
 extern crate toml;
 
@@ -294,7 +295,7 @@ mod types;
 mod parse;
 
 
-pub use syntax::errors::Level;
+pub use errors::Level;
 
 /// Describes an error encountered by the compiler.
 ///
@@ -320,6 +321,7 @@ impl std::error::Error for Error {
             Level::Warning => "warning",
             Level::Note => "note",
             Level::Help => "help",
+            _ => unreachable!(),
         }
     }
 }
@@ -336,8 +338,9 @@ impl Error {
                 Level::Fatal => { sess.span_diagnostic.span_fatal(span, &self.message); },
                 Level::Error => { sess.span_diagnostic.span_err(span, &self.message); },
                 Level::Warning => { sess.span_diagnostic.span_warn(span, &self.message); },
-                Level::Note => { sess.span_diagnostic.span_note(span, &self.message); },
-                Level::Help => { sess.span_diagnostic.span_help(span, &self.message); },
+                Level::Note => { sess.span_diagnostic.span_note_without_error(span, &self.message); },
+                Level::Help => { sess.span_diagnostic.struct_dummy().span_help(span, &self.message); },
+                _ => unreachable!(),
             };
         } else {
             match self.level {
@@ -345,8 +348,9 @@ impl Error {
                 Level::Fatal => { sess.span_diagnostic.fatal(&self.message); },
                 Level::Error => { sess.span_diagnostic.err(&self.message); },
                 Level::Warning => { sess.span_diagnostic.warn(&self.message); },
-                Level::Note => { sess.span_diagnostic.note(&self.message); },
-                Level::Help => { sess.span_diagnostic.help(&self.message); },
+                Level::Note => { sess.span_diagnostic.note_without_error(&self.message); },
+                Level::Help => { sess.span_diagnostic.struct_dummy().help(&self.message); },
+                _ => unreachable!(),
             };
         }
     }
@@ -465,14 +469,17 @@ impl Cheddar {
     pub fn module(&mut self, module: &str) -> Result<&mut Cheddar, Vec<Error>> {
         // TODO: `parse_item_from_source_str` doesn't work. Why?
         let sess = syntax::parse::ParseSess::new();
-        let mut parser = ::syntax::parse::new_parser_from_source_str(
-            &sess,
-            vec![],
-            "".into(),
-            module.into(),
-        );
+        let result = {
+            let mut parser = ::syntax::parse::new_parser_from_source_str(
+                &sess,
+                vec![],
+                "".into(),
+                module.into(),
+            );
+            parser.parse_path(syntax::parse::parser::PathStyle::Mod)
+        };
 
-        if let Ok(path) = parser.parse_path(syntax::parse::parser::PathParsingMode::NoTypesAllowed) {
+        if let Ok(path) = result {
             self.module = Some(path);
             Ok(self)
         } else {
@@ -511,7 +518,7 @@ impl Cheddar {
                 vec![],
                 sess,
             ),
-        };
+        }.unwrap();
 
         if let Some(ref module) = self.module {
             parse::parse_crate(&krate, module)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,9 +638,9 @@ fn source_file_from_cargo() -> std::result::Result<String, Error> {
         }),
     };
 
-    let table = match toml::Parser::new(&buf).parse() {
-        Some(value) => value,
-        None => return Err(Error {
+    let table = match (&buf).parse::<toml::Value>() {
+        Ok(value) => value,
+        Err(..) => return Err(Error {
             level: Level::Fatal,
             span: None,
             message: "could not parse cargo manifest".into(),
@@ -649,7 +649,7 @@ fn source_file_from_cargo() -> std::result::Result<String, Error> {
 
     // If not explicitly stated then defaults to `src/lib.rs`.
     Ok(table.get("lib")
-        .and_then(|t| t.lookup("path"))
+        .and_then(|t| t.get("path"))
         .and_then(|s| s.as_str())
         .unwrap_or(default)
         .into())

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -18,7 +18,7 @@ use Level;
 
 /// Check that an expected path has been `pub use`d.
 fn check_pub_use(item: &ast::Item, expected: &ast::Path) -> bool {
-    if let ast::Item_::ItemUse(ref path) = item.node {
+    if let ast::ItemKind::Use(ref path) = item.node {
         // API has to be public to be used.
         if let ast::Visibility::Public = item.vis {
             // Easiest way to ensure all of API has been brought into scope.
@@ -58,7 +58,7 @@ pub fn parse_crate(krate: &ast::Crate, path: &ast::Path) -> Result<String, Vec<E
     for module in &path.segments {
         let mut found = false;
         for item in &current_module.items {
-            if let ast::Item_::ItemMod(ref new_module) = item.node {
+            if let ast::ItemKind::Mod(ref new_module) = item.node {
                 if module.identifier == item.ident {
                     current_module = new_module;
                     found = true;
@@ -95,10 +95,10 @@ pub fn parse_mod(module: &ast::Mod) -> Result<String, Vec<Error>> {
             // TODO: Check for ItemStatic and ItemConst as well.
             //     - How would this work?
             //     - Is it even possible?
-            ast::Item_::ItemTy(..) => parse_ty(item),
-            ast::Item_::ItemEnum(..) => parse_enum(item),
-            ast::Item_::ItemStruct(..) => parse_struct(item),
-            ast::Item_::ItemFn(..) => parse_fn(item),
+            ast::ItemKind::Ty(..) => parse_ty(item),
+            ast::ItemKind::Enum(..) => parse_enum(item),
+            ast::ItemKind::Struct(..) => parse_struct(item),
+            ast::ItemKind::Fn(..) => parse_fn(item),
             _ => Ok(None),
         };
 
@@ -129,7 +129,7 @@ fn parse_ty(item: &ast::Item) -> Result<Option<String>, Error> {
 
     let name = item.ident.name.as_str();
     let new_type = match item.node {
-        ast::Item_::ItemTy(ref ty, ref generics) => {
+        ast::ItemKind::Ty(ref ty, ref generics) => {
             // Can not yet convert generics.
             if generics.is_parameterized() { return Ok(None); }
 
@@ -165,7 +165,7 @@ fn parse_enum(item: &ast::Item) -> Result<Option<String>, Error> {
 
     let name = item.ident.name.as_str();
     buffer.push_str(&format!("typedef enum {} {{\n", name));
-    if let ast::Item_::ItemEnum(ref definition, ref generics) = item.node {
+    if let ast::ItemKind::Enum(ref definition, ref generics) = item.node {
         if generics.is_parameterized() {
             return Err(Error {
                 level: Level::Error,
@@ -218,7 +218,7 @@ fn parse_struct(item: &ast::Item) -> Result<Option<String>, Error> {
     let name = item.ident.name.as_str();
     buffer.push_str(&format!("typedef struct {}", name));
 
-    if let ast::Item_::ItemStruct(ref variants, ref generics) = item.node {
+    if let ast::ItemKind::Struct(ref variants, ref generics) = item.node {
         if generics.is_parameterized() {
             return Err(Error {
                 level: Level::Error,
@@ -231,14 +231,14 @@ fn parse_struct(item: &ast::Item) -> Result<Option<String>, Error> {
             buffer.push_str(" {\n");
 
             for field in variants.fields() {
-                let (_, docs) = parse_attr(&field.node.attrs, |_| true, |attr| retrieve_docstring(attr, "\t"));
+                let (_, docs) = parse_attr(&field.attrs, |_| true, |attr| retrieve_docstring(attr, "\t"));
                 buffer.push_str(&docs);
 
-                let name = match field.node.ident() {
+                let name = match field.ident {
                     Some(name) => name.name.as_str(),
                     None => unreachable!("a tuple struct snuck through"),
                 };
-                let ty = try_some!(types::rust_to_c(&*field.node.ty, &name));
+                let ty = try_some!(types::rust_to_c(&*field.ty, &name));
                 buffer.push_str(&format!("\t{};\n", ty));
             }
 
@@ -280,7 +280,7 @@ fn parse_fn(item: &ast::Item) -> Result<Option<String>, Error> {
     let name = item.ident.name.as_str();
     buffer.push_str(&docs);
 
-    if let ast::Item_::ItemFn(ref fn_decl, _, _, abi, ref generics, _) = item.node {
+    if let ast::ItemKind::Fn(ref fn_decl, _, _, abi, ref generics, _) = item.node {
         use syntax::abi::Abi;
         match abi {
             // If it doesn't have a C ABI it can't be called from C.
@@ -305,9 +305,9 @@ fn parse_fn(item: &ast::Item) -> Result<Option<String>, Error> {
         let has_args = !fn_decl.inputs.is_empty();
 
         for arg in &fn_decl.inputs {
-            use syntax::ast::{PatIdent, BindingMode};
+            use syntax::ast::{PatKind, BindingMode};
             let arg_name = match arg.pat.node {
-                PatIdent(BindingMode::ByValue(_), ref ident, None) => {
+                PatKind::Ident(BindingMode::ByValue(_), ref ident, None) => {
                     ident.node.name.to_string()
                 }
                 _ => return Err(Error {
@@ -335,15 +335,15 @@ fn parse_fn(item: &ast::Item) -> Result<Option<String>, Error> {
 
         let output_type = &fn_decl.output;
         let full_declaration = match *output_type {
-            ast::FunctionRetTy::NoReturn(span) => {
+            ast::FunctionRetTy::Ty(ref ty) if ty.node == ast::TyKind::Never => {
                 return Err(Error {
                     level: Level::Error,
-                    span: Some(span),
+                    span: Some(ty.span),
                     message: "panics across a C boundary are naughty!".into(),
                 });
             },
-            ast::FunctionRetTy::DefaultReturn(..) => format!("void {}", buf_without_return),
-            ast::FunctionRetTy::Return(ref ty) => try_some!(types::rust_to_c(&*ty, &buf_without_return)),
+            ast::FunctionRetTy::Default(..) => format!("void {}", buf_without_return),
+            ast::FunctionRetTy::Ty(ref ty) => try_some!(types::rust_to_c(&*ty, &buf_without_return)),
         };
 
         buffer.push_str(&full_declaration);
@@ -384,10 +384,10 @@ fn parse_attr<C, R>(attrs: &[ast::Attribute], check: C, retrieve: R) -> (bool, S
 /// Check the attribute is #[repr(C)].
 fn check_repr_c(attr: &ast::Attribute) -> bool {
     match attr.node.value.node {
-        ast::MetaItem_::MetaList(ref name, ref word) if *name == "repr" => match word.first() {
+        ast::MetaItemKind::List(ref name, ref word) if *name == "repr" => match word.first() {
             Some(word) => match word.node {
                 // Return true only if attribute is #[repr(C)].
-                ast::MetaItem_::MetaWord(ref name) if *name == "C" => true,
+                ast::MetaItemKind::Word(ref name) if *name == "C" => true,
                 _ => false,
             },
             _ => false,
@@ -399,7 +399,7 @@ fn check_repr_c(attr: &ast::Attribute) -> bool {
 /// Check the attribute is #[no_mangle].
 fn check_no_mangle(attr: &ast::Attribute) -> bool {
     match attr.node.value.node {
-        ast::MetaItem_::MetaWord(ref name) if *name == "no_mangle" => true,
+        ast::MetaItemKind::Word(ref name) if *name == "no_mangle" => true,
         _ => false,
     }
 }
@@ -407,9 +407,9 @@ fn check_no_mangle(attr: &ast::Attribute) -> bool {
 /// If the attribute is  a docstring, indent it the required amount and return it.
 fn retrieve_docstring(attr: &ast::Attribute, prepend: &str) -> Option<String> {
     match attr.node.value.node {
-        ast::MetaItem_::MetaNameValue(ref name, ref val) if *name == "doc" => match val.node {
+        ast::MetaItemKind::NameValue(ref name, ref val) if *name == "doc" => match val.node {
             // Docstring attributes omit the trailing newline.
-            ast::Lit_::LitStr(ref docs, _) => Some(format!("{}{}\n", prepend, docs)),
+            ast::LitKind::Str(ref docs, _) => Some(format!("{}{}\n", prepend, docs)),
             _ => unreachable!("docs must be literal strings"),
         },
         _ => None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use Level;
 pub fn rust_to_c(ty: &ast::Ty, assoc: &str) -> Result<Option<String>, Error> {
     match ty.node {
         // Function pointers make life an absolute pain here.
-        ast::Ty_::TyBareFn(ref bare_fn) => fn_ptr_to_c(bare_fn, ty.span, assoc),
+        ast::TyKind::BareFn(ref bare_fn) => fn_ptr_to_c(bare_fn, ty.span, assoc),
         // All other types just have a name associated with them.
         _ => Ok(Some(format!("{} {}", try_some!(anon_rust_to_c(ty)), assoc))),
     }
@@ -21,15 +21,15 @@ pub fn rust_to_c(ty: &ast::Ty, assoc: &str) -> Result<Option<String>, Error> {
 fn anon_rust_to_c(ty: &ast::Ty) -> Result<Option<String>, Error> {
     match ty.node {
         // Function pointers should not be in this function.
-        ast::Ty_::TyBareFn(..) => Err(Error {
+        ast::TyKind::BareFn(..) => Err(Error {
             level: Level::Error,
             span: Some(ty.span),
             message: "C function pointers must have a name or function declaration associated with them".into(),
         }),
         // Standard pointers.
-        ast::Ty_::TyPtr(ref ptr) => ptr_to_c(ptr),
+        ast::TyKind::Ptr(ref ptr) => ptr_to_c(ptr),
         // Plain old types.
-        ast::Ty_::TyPath(None, ref path) => path_to_c(path),
+        ast::TyKind::Path(None, ref path) => path_to_c(path),
         // Possibly void, likely not.
         _ => {
             let new_type = print::pprust::ty_to_string(ty);
@@ -51,9 +51,9 @@ fn ptr_to_c(ty: &ast::MutTy) -> Result<Option<String>, Error> {
     let new_type = try_some!(anon_rust_to_c(&ty.ty));
     let const_spec = match ty.mutbl {
         // *const T
-        ast::Mutability::MutImmutable => " const" ,
+        ast::Mutability::Immutable => " const" ,
         // *mut T
-        ast::Mutability::MutMutable => "",
+        ast::Mutability::Mutable => "",
     };
 
     Ok(Some(format!("{}{}*", new_type, const_spec)))
@@ -115,15 +115,15 @@ fn fn_ptr_to_c(fn_ty: &ast::BareFnTy, fn_span: codemap::Span, inner: &str) -> Re
 
     let output_type = &fn_decl.output;
     let full_declaration = match *output_type {
-        ast::FunctionRetTy::NoReturn(span) => {
+        ast::FunctionRetTy::Ty(ref ty) if ty.node == ast::TyKind::Never => {
             return Err(Error {
                 level: Level::Error,
-                span: Some(span),
+                span: Some(ty.span),
                 message: "panics across a C boundary are naughty!".into(),
             });
         },
-        ast::FunctionRetTy::DefaultReturn(..) => format!("void {}", buf_without_return),
-        ast::FunctionRetTy::Return(ref ty) => try_some!(rust_to_c(&*ty, &buf_without_return)),
+        ast::FunctionRetTy::Default(..) => format!("void {}", buf_without_return),
+        ast::FunctionRetTy::Ty(ref ty) => try_some!(rust_to_c(&*ty, &buf_without_return)),
     };
 
 
@@ -244,14 +244,17 @@ fn rust_ty_to_c(ty: &str) -> &str {
 mod test {
     fn ty(source: &str) -> ::syntax::ast::Ty {
         let sess = ::syntax::parse::ParseSess::new();
-        let mut parser = ::syntax::parse::new_parser_from_source_str(
-            &sess,
-            vec![],
-            "".into(),
-            source.into(),
-        );
+        let result = {
+            let mut parser = ::syntax::parse::new_parser_from_source_str(
+                &sess,
+                vec![],
+                "".into(),
+                source.into(),
+            );
+            parser.parse_ty()
+        };
 
-        match parser.parse_ty() {
+        match result {
             Ok(p) => (*p).clone(),
             _ => panic!("internal testing error: could not parse type from {:?}", source),
         }


### PR DESCRIPTION
Here's all the outstanding pull requests from the upstream repository. Not the ideal rebase order, but at least it brings things up to date a bit.

Doesn't address the build failure on 1.18.0-nightly. I suspect we need another `syntex` bump to get a compatible `serde_derive`.